### PR TITLE
Fixes a python 3 compatibility issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ install:
 
   # conda dependencies that pip does not install
   - pip install enum34
+  - pip install future
 
 
 script:

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -5,3 +5,4 @@ bash miniconda.sh -b -p $HOME/miniconda
 export PATH="$HOME/miniconda/bin:$PATH"
 
 conda install numba pyzmq futures
+pip install future

--- a/numbskull/numbskull.py
+++ b/numbskull/numbskull.py
@@ -3,7 +3,7 @@
 """TODO: This is a docstring."""
 
 from __future__ import print_function, absolute_import
-from builtins import int
+from past.builtins import long
 import os
 import sys
 import argparse
@@ -202,6 +202,7 @@ class NumbSkull(object):
         assert(type(domain_mask) == np.ndarray and
                domain_mask.dtype == np.bool)
         assert(type(edges) == int or
+               type(edges) == long or
                type(edges) == np.int64)
         assert(type(factors_to_skip) == np.ndarray and
                factors_to_skip.dtype == np.int64)

--- a/numbskull/numbskull.py
+++ b/numbskull/numbskull.py
@@ -3,6 +3,7 @@
 """TODO: This is a docstring."""
 
 from __future__ import print_function, absolute_import
+from builtins import int
 import os
 import sys
 import argparse
@@ -201,7 +202,6 @@ class NumbSkull(object):
         assert(type(domain_mask) == np.ndarray and
                domain_mask.dtype == np.bool)
         assert(type(edges) == int or
-               type(edges) == long or
                type(edges) == np.int64)
         assert(type(factors_to_skip) == np.ndarray and
                factors_to_skip.dtype == np.int64)


### PR DESCRIPTION
An issue with checking for type `long` which no longer exists in Python 3; fixed according to [this guide](http://python-future.org/compatible_idioms.html#long-integers) (need this for tests to pass / stuff to work with Python 3 in Snorkel- thanks!)