### PR TITLE
Restore futures install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,10 @@ setup(
     version=__version__,
     description='sample away',
     packages=find_packages(),
-    install_requires=['future'],
+    install_requires=[
+        'future',
+        'futures',
+    ],
     entry_points={
         'console_scripts': [
             'numbskull = numbskull.numbskull:main',


### PR DESCRIPTION
https://github.com/HazyResearch/numbskull/pull/52 removed `futures`, but instead we need to require both `futures` and `future`.